### PR TITLE
Fix AGWeakAttribute symbol mangling issue

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/OpenSwiftUIProject/DarwinPrivateFrameworks.git",
       "state" : {
         "branch" : "main",
-        "revision" : "fdb349e4715fafdb847852e03c414739b21ae8b8"
+        "revision" : "00977e88d14f98c248bf1c8370855ad6ecc35977"
       }
     },
     {

--- a/Sources/OpenAttributeGraph/Attribute/Weak/AnyWeakAttribute.swift
+++ b/Sources/OpenAttributeGraph/Attribute/Weak/AnyWeakAttribute.swift
@@ -2,28 +2,24 @@
 //  AnyWeakAttribute.swift
 //  OpenAttributeGraph
 //
-//  Audited for RELEASE_2021
+//  Audited for 6.5.1
 //  Status: Complete
 
 public import OpenAttributeGraphCxx
 
 extension AnyWeakAttribute {
-    @_alwaysEmitIntoClient
     public init(_ attribute: AnyAttribute?) {
         self = __OAGCreateWeakAttribute(attribute ?? .nil)
     }
 
-    @_alwaysEmitIntoClient
     public init<Value>(_ weakAttribute: WeakAttribute<Value>) {
         self = weakAttribute.base
     }
     
-    @_alwaysEmitIntoClient
     public func unsafeCast<Value>(to _: Value.Type) -> WeakAttribute<Value> {
         WeakAttribute(base: self)
     }
     
-    @_alwaysEmitIntoClient
     public var attribute: AnyAttribute? {
         get {
             let attribute = __OAGWeakAttributeGetAttribute(self)
@@ -36,24 +32,20 @@ extension AnyWeakAttribute {
 }
 
 extension AnyWeakAttribute: Swift.Hashable {
-    @_alwaysEmitIntoClient
     public static func == (lhs: AnyWeakAttribute, rhs: AnyWeakAttribute) -> Bool {
         lhs._details.identifier == rhs._details.identifier && lhs._details.seed == rhs._details.seed
     }
     
-    @_alwaysEmitIntoClient
     public func hash(into hasher: inout Hasher) {
         hasher.combine(_details.identifier)
         hasher.combine(_details.seed)
     }
     
-    @_alwaysEmitIntoClient
     public var hashValue: Int {
         _hashValue(for: self)
     }
 }
 
 extension AnyWeakAttribute: Swift.CustomStringConvertible {
-    @_alwaysEmitIntoClient
     public var description: String { attribute?.description ?? "nil" }
 }

--- a/Sources/OpenAttributeGraph/Attribute/Weak/AnyWeakAttribute.swift
+++ b/Sources/OpenAttributeGraph/Attribute/Weak/AnyWeakAttribute.swift
@@ -7,25 +7,19 @@
 
 public import OpenAttributeGraphCxx
 
-// FIXME: For some unknown reason, AnyWeakAttribute and WeakAttribute's symbol can't be linked.
-
 extension AnyWeakAttribute {
-    @_alwaysEmitIntoClient
     public init(_ attribute: AnyAttribute?) {
         self = __OAGCreateWeakAttribute(attribute ?? .nil)
     }
 
-    @_alwaysEmitIntoClient
     public init<Value>(_ weakAttribute: WeakAttribute<Value>) {
         self = weakAttribute.base
     }
 
-    @_alwaysEmitIntoClient
     public func unsafeCast<Value>(to _: Value.Type) -> WeakAttribute<Value> {
         WeakAttribute(base: self)
     }
 
-    @_alwaysEmitIntoClient
     public var attribute: AnyAttribute? {
         get {
             let attribute = __OAGWeakAttributeGetAttribute(self)
@@ -38,20 +32,13 @@ extension AnyWeakAttribute {
 }
 
 extension AnyWeakAttribute: Swift.Hashable {
-    @_alwaysEmitIntoClient
     public static func == (lhs: AnyWeakAttribute, rhs: AnyWeakAttribute) -> Bool {
         lhs._details.identifier == rhs._details.identifier && lhs._details.seed == rhs._details.seed
     }
 
-    @_alwaysEmitIntoClient
     public func hash(into hasher: inout Hasher) {
         hasher.combine(_details.identifier)
         hasher.combine(_details.seed)
-    }
-
-    @_alwaysEmitIntoClient
-    public var hashValue: Int {
-        _hashValue(for: self)
     }
 }
 

--- a/Sources/OpenAttributeGraph/Attribute/Weak/AnyWeakAttribute.swift
+++ b/Sources/OpenAttributeGraph/Attribute/Weak/AnyWeakAttribute.swift
@@ -7,19 +7,25 @@
 
 public import OpenAttributeGraphCxx
 
+// FIXME: For some unknown reason, AnyWeakAttribute and WeakAttribute's symbol can't be linked.
+
 extension AnyWeakAttribute {
+    @_alwaysEmitIntoClient
     public init(_ attribute: AnyAttribute?) {
         self = __OAGCreateWeakAttribute(attribute ?? .nil)
     }
 
+    @_alwaysEmitIntoClient
     public init<Value>(_ weakAttribute: WeakAttribute<Value>) {
         self = weakAttribute.base
     }
-    
+
+    @_alwaysEmitIntoClient
     public func unsafeCast<Value>(to _: Value.Type) -> WeakAttribute<Value> {
         WeakAttribute(base: self)
     }
-    
+
+    @_alwaysEmitIntoClient
     public var attribute: AnyAttribute? {
         get {
             let attribute = __OAGWeakAttributeGetAttribute(self)
@@ -32,20 +38,24 @@ extension AnyWeakAttribute {
 }
 
 extension AnyWeakAttribute: Swift.Hashable {
+    @_alwaysEmitIntoClient
     public static func == (lhs: AnyWeakAttribute, rhs: AnyWeakAttribute) -> Bool {
         lhs._details.identifier == rhs._details.identifier && lhs._details.seed == rhs._details.seed
     }
-    
+
+    @_alwaysEmitIntoClient
     public func hash(into hasher: inout Hasher) {
         hasher.combine(_details.identifier)
         hasher.combine(_details.seed)
     }
-    
+
+    @_alwaysEmitIntoClient
     public var hashValue: Int {
         _hashValue(for: self)
     }
 }
 
 extension AnyWeakAttribute: Swift.CustomStringConvertible {
+    @_alwaysEmitIntoClient
     public var description: String { attribute?.description ?? "nil" }
 }

--- a/Sources/OpenAttributeGraph/Attribute/Weak/AnyWeakAttribute.swift
+++ b/Sources/OpenAttributeGraph/Attribute/Weak/AnyWeakAttribute.swift
@@ -7,8 +7,6 @@
 
 public import OpenAttributeGraphCxx
 
-public typealias AnyWeakAttribute = OAGWeakAttribute
-
 extension AnyWeakAttribute {
     @_alwaysEmitIntoClient
     public init(_ attribute: AnyAttribute?) {

--- a/Sources/OpenAttributeGraph/Attribute/Weak/WeakAttribute.swift
+++ b/Sources/OpenAttributeGraph/Attribute/Weak/WeakAttribute.swift
@@ -7,36 +7,28 @@
 
 public import OpenAttributeGraphCxx
 
-// FIXME: For some unknown reason, AnyWeakAttribute and WeakAttribute's symbol can't be linked.
-
 @frozen
 @propertyWrapper
 @dynamicMemberLookup
 public struct WeakAttribute<Value> {
-    @usableFromInline
     var base: AnyWeakAttribute
 
-    @_alwaysEmitIntoClient
     public init(base: AnyWeakAttribute) {
         self.base = base
     }
 
-    @_alwaysEmitIntoClient
     public init() {
         base = AnyWeakAttribute(_details: .init(identifier: .init(rawValue: 0), seed: 0))
     }
 
-    @_alwaysEmitIntoClient
     public init(_ attribute: Attribute<Value>) {
         base = AnyWeakAttribute(attribute.identifier)
     }
 
-    @_alwaysEmitIntoClient
     public init(_ attribute: Attribute<Value>?) {
         base = AnyWeakAttribute(attribute?.identifier)
     }
 
-    @_alwaysEmitIntoClient
     public var wrappedValue: Value? {
         OAGGraphGetWeakValue(base, type: Value.self)
             .value?
@@ -44,28 +36,23 @@ public struct WeakAttribute<Value> {
             .pointee
     }
 
-    @_alwaysEmitIntoClient
     public var projectedValue: Attribute<Value>?{
         get { attribute }
         set { attribute = newValue }
         _modify { yield &attribute }
     }
 
-    @_alwaysEmitIntoClient
     public subscript<Member>(dynamicMember keyPath: KeyPath<Value, Member>) -> Attribute<Member>? {
         attribute?[keyPath: keyPath]
     }
 
-    @_alwaysEmitIntoClient
     public var attribute: Attribute<Value>? {
         get { base.attribute?.unsafeCast(to: Value.self) }
         set { base.attribute = newValue?.identifier }
     }
 
-    @_alwaysEmitIntoClient
     public var value: Value? { wrappedValue }
 
-    @_alwaysEmitIntoClient
     public func changedValue(options: OAGValueOptions) -> (value: Value, changed: Bool)? {
         let value = OAGGraphGetWeakValue(base, options: options, type: Value.self)
         guard let ptr = value.value else {
@@ -85,5 +72,4 @@ extension WeakAttribute: CustomStringConvertible {
 }
 
 @_silgen_name("OAGGraphGetWeakValue")
-@_alwaysEmitIntoClient
 private func OAGGraphGetWeakValue<Value>(_ attribute: AnyWeakAttribute, options: OAGValueOptions = [], type: Value.Type = Value.self) -> OAGWeakValue

--- a/Sources/OpenAttributeGraph/Attribute/Weak/WeakAttribute.swift
+++ b/Sources/OpenAttributeGraph/Attribute/Weak/WeakAttribute.swift
@@ -7,52 +7,65 @@
 
 public import OpenAttributeGraphCxx
 
+// FIXME: For some unknown reason, AnyWeakAttribute and WeakAttribute's symbol can't be linked.
+
 @frozen
 @propertyWrapper
 @dynamicMemberLookup
 public struct WeakAttribute<Value> {
+    @usableFromInline
     var base: AnyWeakAttribute
-    
+
+    @_alwaysEmitIntoClient
     public init(base: AnyWeakAttribute) {
         self.base = base
     }
-    
+
+    @_alwaysEmitIntoClient
     public init() {
         base = AnyWeakAttribute(_details: .init(identifier: .init(rawValue: 0), seed: 0))
     }
-    
+
+    @_alwaysEmitIntoClient
     public init(_ attribute: Attribute<Value>) {
         base = AnyWeakAttribute(attribute.identifier)
     }
-    
+
+    @_alwaysEmitIntoClient
     public init(_ attribute: Attribute<Value>?) {
         base = AnyWeakAttribute(attribute?.identifier)
     }
-    
+
+    @_alwaysEmitIntoClient
     public var wrappedValue: Value? {
         OAGGraphGetWeakValue(base, type: Value.self)
             .value?
             .assumingMemoryBound(to: Value.self)
             .pointee
     }
-    
+
+    @_alwaysEmitIntoClient
     public var projectedValue: Attribute<Value>?{
         get { attribute }
         set { attribute = newValue }
         _modify { yield &attribute }
     }
-    
+
+    @_alwaysEmitIntoClient
     public subscript<Member>(dynamicMember keyPath: KeyPath<Value, Member>) -> Attribute<Member>? {
         attribute?[keyPath: keyPath]
     }
-    
+
+    @_alwaysEmitIntoClient
     public var attribute: Attribute<Value>? {
         get { base.attribute?.unsafeCast(to: Value.self) }
         set { base.attribute = newValue?.identifier }
     }
-    
+
+    @_alwaysEmitIntoClient
     public var value: Value? { wrappedValue }
 
+    @_alwaysEmitIntoClient
     public func changedValue(options: OAGValueOptions) -> (value: Value, changed: Bool)? {
         let value = OAGGraphGetWeakValue(base, options: options, type: Value.self)
         guard let ptr = value.value else {
@@ -72,4 +85,5 @@ extension WeakAttribute: CustomStringConvertible {
 }
 
 @_silgen_name("OAGGraphGetWeakValue")
+@_alwaysEmitIntoClient
 private func OAGGraphGetWeakValue<Value>(_ attribute: AnyWeakAttribute, options: OAGValueOptions = [], type: Value.Type = Value.self) -> OAGWeakValue

--- a/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGWeakAttribute.h
+++ b/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGWeakAttribute.h
@@ -11,12 +11,12 @@
 
 OAG_ASSUME_NONNULL_BEGIN
 
-typedef struct OAG_SWIFT_NAME(AnyWeakAttribute) OAGWeakAttribute {
+typedef OAG_SWIFT_STRUCT struct {
     struct {
         OAGAttribute identifier;
         uint32_t seed;
     } _details;
-} OAGWeakAttribute;
+} OAGWeakAttribute OAG_SWIFT_NAME(AnyWeakAttribute);
 
 OAG_EXTERN_C_BEGIN
 

--- a/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGWeakAttribute.h
+++ b/Sources/OpenAttributeGraphCxx/include/OpenAttributeGraph/OAGWeakAttribute.h
@@ -11,12 +11,12 @@
 
 OAG_ASSUME_NONNULL_BEGIN
 
-typedef struct OAGWeakAttribute {
+typedef struct OAG_SWIFT_NAME(AnyWeakAttribute) OAGWeakAttribute {
     struct {
         OAGAttribute identifier;
         uint32_t seed;
     } _details;
-} OAGWeakAttribute OAG_SWIFT_NAME(AnyWeakAttribute);
+} OAGWeakAttribute;
 
 OAG_EXTERN_C_BEGIN
 

--- a/Tests/OpenAttributeGraphCompatibilityTests/Attribute/Attribute/AnyAttributeCompatibilityTests.swift
+++ b/Tests/OpenAttributeGraphCompatibilityTests/Attribute/Attribute/AnyAttributeCompatibilityTests.swift
@@ -98,6 +98,12 @@ struct AnyAttributeCompatibilityTests {
             }
         }
     }
+
+    @Test
+    func subgraph() {
+        let identifier = Attribute(value: 0).identifier
+        #expect(identifier.subgraph2 != nil)
+    }
     #endif
 }
 #endif

--- a/Tests/OpenAttributeGraphCompatibilityTests/Attribute/Weak/AnyWeakAttributeCompatibilityTests.swift
+++ b/Tests/OpenAttributeGraphCompatibilityTests/Attribute/Weak/AnyWeakAttributeCompatibilityTests.swift
@@ -33,5 +33,17 @@ struct AnyWeakAttributeCompatibilityTests {
         }
         #expect(AnyWeakAttribute(nil).description == "nil")
     }
+
+    @Test
+    func dict() {
+        let w1 = AnyWeakAttribute(nil)
+        let w2 = AnyWeakAttribute(WeakAttribute<Void>(nil))
+        let dict: [AnyWeakAttribute: Int] = [
+            w1: 1,
+            w2: 2,
+        ]
+        #expect(dict[w1] == 1)
+        #expect(dict[w2] == 2)
+    }
 }
 #endif

--- a/Tests/OpenAttributeGraphCompatibilityTests/Attribute/Weak/AnyWeakAttributeCompatibilityTests.swift
+++ b/Tests/OpenAttributeGraphCompatibilityTests/Attribute/Weak/AnyWeakAttributeCompatibilityTests.swift
@@ -37,7 +37,7 @@ struct AnyWeakAttributeCompatibilityTests {
     @Test
     func dict() {
         let w1 = AnyWeakAttribute(nil)
-        let w2 = AnyWeakAttribute(WeakAttribute<Void>(nil))
+        let w2 = AnyWeakAttribute(Attribute(value: 0).identifier)
         let dict: [AnyWeakAttribute: Int] = [
             w1: 1,
             w2: 2,


### PR DESCRIPTION
## Summary
Fixes the linking error when using `AGWeakAttribute` as a dictionary key by correcting the symbol mangling from struct (V) to the expected type.

## Problem
The symbol was being mangled as `sSo15AGWeakAttributeVSH0B5GraphMc` (struct) instead of `sSo15AGWeakAttributeaSH0B5GraphMc` (type alias), causing undefined symbol errors during linking.

## Solution
Updated the C header declaration to use `AG_SWIFT_STRUCT` macro which ensures proper Swift import behavior while maintaining ABI compatibility with the system framework.

## Test Plan
- [x] Verified that AGExample_2024 builds and runs successfully
- [x] Confirmed the symbol is now correctly mangled
- [x] Tested that `AGWeakAttribute` can be used as a dictionary key without link errors

Fixes #178