### PR TITLE
Add PR triage workflow

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,14 @@
+name: PR Triage
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage-pr:
+    uses: OpenSwiftUIProject/github-workflows/.github/workflows/pr-triage.yml@main
+    secrets: inherit


### PR DESCRIPTION
Add automated PR triage workflow that uses Claude AI to automatically analyze and label pull requests.

This workflow:
- Triggers when new PRs are opened
- Uses the shared pr-triage workflow from OpenSwiftUIProject/github-workflows
- Automatically applies appropriate labels based on PR content
- Inherits necessary secrets for authentication

Follows the same pattern as the existing issue-triage workflow.